### PR TITLE
Add support for X3D file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ console.log(JSON.stringify(fileType)); // Outputs: {"ext":"svg","mime":"image/sv
 - [SVG: (Scalable Vector Graphics)](https://en.wikipedia.org/wiki/SVG)
 - [TEI, Text Encoding Initiative](https://en.wikipedia.org/wiki/Text_Encoding_Initiative)
 - [TTML: (Timed Text Markup Language)](https://en.wikipedia.org/wiki/Timed_Text_Markup_Language)
+- [X3D (Extensible 3D)](https://en.wikipedia.org/wiki/X3D)
 - [XHTML](https://en.wikipedia.org/wiki/XHTML)
 - [XLIFF (XML Localization Interchange File Format)](https://en.wikipedia.org/wiki/XLIFF)
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -81,6 +81,10 @@ export const fileType = {
 	svg: {
 		ext: 'svg',
 		mime: 'image/svg+xml'
+	},
+	x3d: {
+		ext: 'x3d',
+		mime: 'model/x3d+xml'
 	}
 } as const satisfies Record<string, FileTypeResult>;
 
@@ -152,7 +156,8 @@ const docTypeMapping: { [id: string]: FileTypeResult; } = {
 	'-//OASIS//DTD DocBook XML V4.4//EN': fileType.docBook,
 	'-//OASIS//DTD DocBook XML V4.5//EN': fileType.docBook,
 	'-//Recordare//DTD MusicXML 4.0 Partwise//EN': fileType.musicXml,
-	'-//Apple//DTD PLIST 1.0//EN': fileType.plist
+	'-//Apple//DTD PLIST 1.0//EN': fileType.plist,
+	'ISO//Web3D//DTD X3D 3.3//EN': fileType.x3d,
 };
 
 export class XmlTextDetector {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"xliff",
 		"xlf",
 		"docbook",
-		"tei"
+		"tei",
+		"x3d"
 	],
 	"dependencies": {
 		"sax": "^1.4.4",

--- a/test/fixture/BoxExample.x3d
+++ b/test/fixture/BoxExample.x3d
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE X3D PUBLIC "ISO//Web3D//DTD X3D 3.3//EN" "https://www.web3d.org/specifications/x3d-3.3.dtd">
+<X3D profile='Interchange' version='3.3' xmlns:xsd='http://www.w3.org/2001/XMLSchema-instance' xsd:noNamespaceSchemaLocation='https://www.web3d.org/specifications/x3d-3.3.xsd'>
+  <head>
+    <meta content='BoxExample.x3d' name='title'/>
+    <meta content='Box geometric primitive node.' name='description'/>
+    <meta content='Leonard Daly' name='creator'/>
+    <meta content='1 January 2007' name='created'/>
+    <meta content='8 March 2022' name='modified'/>
+    <meta content='https://X3dGraphics.com' name='reference'/>
+    <meta content='https://www.web3d.org/x3d/content/examples/X3dResources.html' name='reference'/>
+    <meta content='Copyright Don Brutzman and Leonard Daly 2007' name='rights'/>
+    <meta content='X3D book, X3D graphics, X3D-Edit, http://www.x3dGraphics.com' name='subject'/>
+    <meta content='https://X3dGraphics.com/examples/X3dForWebAuthors/Chapter02GeometryPrimitives/BoxExample.x3d' name='identifier'/>
+    <meta content='X3D-Edit 3.3, https://savage.nps.edu/X3D-Edit' name='generator'/>
+    <meta content='../license.html' name='license'/>
+  </head>
+  <Scene>
+    <WorldInfo title='BoxExample.x3d'/>
+    <Background skyColor='1 1 1'/>
+    <Viewpoint description='Book View' orientation='-0.747 -0.624 -0.231 1.05' position='-1.81 3.12 2.59'/>
+    <Shape>
+      <Box size='1 2 3'/>
+      <Appearance>
+        <Material/>
+      </Appearance>
+    </Shape>
+  </Scene>
+</X3D>

--- a/test/test.js
+++ b/test/test.js
@@ -283,6 +283,20 @@ describe('XML detector', () => {
 			}
 		});
 
+		it('should detect X3D', async () => {
+			const samplePath = getSamplePath('BoxExample.x3d');
+			const tokenizer = await fromFile(samplePath);
+
+			try {
+				const fileType = await detectXml.detect(tokenizer);
+				assert.isDefined(fileType, 'Expected X3D file type to be detected');
+				assert.strictEqual(fileType.mime, 'model/x3d+xml', 'Expected X3D MIME type');
+				assert.strictEqual(fileType.ext, 'x3d', 'Expected X3D file extension');
+			} finally {
+				await tokenizer.close();
+			}
+		});
+
 	});
 
 	describe('Handle different text encoding', () => {


### PR DESCRIPTION
Adds support for detecting [X3D (Extensible 3D) XML files](https://en.wikipedia.org/wiki/X3D), an ISO standard XML-based file format for representing 3D computer graphics.

Added X3D file type definition with: 
- MIME type `model/x3d+xml` and 
- extension `x3d`
